### PR TITLE
Remove custom shell task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,16 +5,13 @@ module.exports = function(grunt) {
     titaniumifier: {
       "module": {
         options: {
+          bundle: true,
+          module: true
         },
         files: [{
           src: ['.'],
           dest: 'dist'
         }]
-      }
-    },
-    shell: {
-      target: {
-        command: '(cd dist; unzip -p nano-commonjs-'+version+'.zip modules/commonjs/nano/'+version+'/nano.js > nano.js)'
       }
     },
     watch: {
@@ -31,7 +28,7 @@ module.exports = function(grunt) {
   require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
 
   grunt.registerTask('default', 'build');
-  grunt.registerTask('build', ['titaniumifier','shell']);
+  grunt.registerTask('build', 'titaniumifier');
   grunt.registerTask('dev', ['build', 'watch']);
 };
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,8 +7,8 @@ module.exports = function(grunt) {
         options: {
         },
         files: [{
-          src:['.'],
-          dest:'dist'
+          src: ['.'],
+          dest: 'dist'
         }]
       }
     },

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
   "devDependencies": {
     "async": "^0.9.0",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-shell": "^1.1.1",
-    "grunt-titaniumifier": "^1.0.1",
+    "grunt-titaniumifier": "^1.1.0",
     "matchdep": "^0.3.0",
     "observe-js": "^0.4.2"
   },


### PR DESCRIPTION
The new `grunt-titaniumifier@1.1.0` introduces the `bundle` and `module` options to fine grain the type of output required.

Now you can just place `grunt-uglify` task to minify the resulting bundle. We’re *probably not* going to include minification directly inside titaniumifier.

I also micro-source-formatted and removed the now useless `grunt-shell` dependency.